### PR TITLE
Added Has Aspect Condition

### DIFF
--- a/src/main/java/dev/overgrown/sync/compatibility/aspectslib/condition/HasAspectCondition.java
+++ b/src/main/java/dev/overgrown/sync/compatibility/aspectslib/condition/HasAspectCondition.java
@@ -1,0 +1,55 @@
+package dev.overgrown.sync.compatibility.aspectslib.condition;
+
+import dev.overgrown.aspectslib.api.IAspectAffinityEntity;
+import dev.overgrown.aspectslib.data.AspectData;
+import dev.overgrown.sync.Sync;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class HasAspectCondition {
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(
+                Sync.identifier("has_aspect"),
+                new SerializableData()
+                        .add("aspect", SerializableDataTypes.IDENTIFIER, null)
+                        .add("aspects", SerializableDataTypes.IDENTIFIERS, null)
+                        .add("min", SerializableDataTypes.INT, 1)
+                        .add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN_OR_EQUAL),
+                (data, entity) -> {
+                    if (!(entity instanceof IAspectAffinityEntity)) {
+                        return false;
+                    }
+
+                    IAspectAffinityEntity aspectEntity = (IAspectAffinityEntity) entity;
+                    AspectData aspectData = aspectEntity.aspectslib$getAspectData();
+                    Comparison comparison = data.get("comparison");
+                    int minLevel = data.getInt("min");
+
+                    if (data.isPresent("aspect")) {
+                        Identifier aspectId = data.getId("aspect");
+                        int level = aspectData.getLevel(aspectId);
+                        return comparison.compare(level, minLevel);
+                    }
+                    else if (data.isPresent("aspects")) {
+                        List<Identifier> aspectIds = data.get("aspects");
+                        for (Identifier aspectId : aspectIds) {
+                            int level = aspectData.getLevel(aspectId);
+                            if (comparison.compare(level, minLevel)) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                    return false;
+                }
+        );
+    }
+}

--- a/src/main/java/dev/overgrown/sync/factory/registry/SyncTypeRegistry.java
+++ b/src/main/java/dev/overgrown/sync/factory/registry/SyncTypeRegistry.java
@@ -2,6 +2,7 @@ package dev.overgrown.sync.factory.registry;
 
 import dev.overgrown.sync.Sync;
 import dev.overgrown.sync.compatibility.aspectslib.SetEntityAspectsPower;
+import dev.overgrown.sync.compatibility.aspectslib.condition.HasAspectCondition;
 import dev.overgrown.sync.factory.action.bientity.AddToEntitySetAction;
 import dev.overgrown.sync.factory.action.bientity.RemoveFromEntitySetAction;
 import dev.overgrown.sync.factory.action.entity.ActionOnEntitySetAction;
@@ -40,6 +41,7 @@ public class SyncTypeRegistry {
 
         if (Sync.HAS_ASPECTSLIB) {
             ApoliRegistryHelper.registerPowerFactory(SetEntityAspectsPower.createFactory());
+            ApoliRegistryHelper.registerEntityCondition(HasAspectCondition.getFactory());
         }
     }
 }

--- a/src/main/resources/data/sync/powers/has_aspect_multiple_aspect_check.json
+++ b/src/main/resources/data/sync/powers/has_aspect_multiple_aspect_check.json
@@ -1,0 +1,16 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "apoli:execute_command",
+    "command": "tellraw @a {\"text\": \"You Have the Ignis and Terra Aspects!\", \"color\": \"red\"}"
+  },
+  "interval": 40,
+  "condition": {
+    "type": "sync:has_aspect",
+    "aspects": [
+      "aspectslib:terra",
+      "aspectslib:ignis"
+    ],
+    "min": 3
+  }
+}

--- a/src/main/resources/data/sync/powers/has_aspect_single_aspect_check.json
+++ b/src/main/resources/data/sync/powers/has_aspect_single_aspect_check.json
@@ -1,0 +1,14 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "apoli:execute_command",
+    "command": "tellraw @a {\"text\": \"You Have the Terra Aspect!\", \"color\": \"green\"}"
+  },
+  "interval": 40,
+  "condition": {
+    "type": "sync:has_aspect",
+    "aspect": "aspectslib:terra",
+    "min": 5,
+    "comparison": ">="
+  }
+}


### PR DESCRIPTION
Created a new class that integrates with the `Apoli` condition system and `AspectsLib` API. Works with both regular entities and entities modified by `SetEntityAspectsPower` and automatically checks if the entity implements `IAspectAffinityEntity`.

The condition defaults comparison to `Comparison.GREATER_THAN_OR_EQUAL` using Apoli's `Comparison.compare()` method to match how Apoli handles comparisons in its conditions, making it more consistent with other Apoli-powered mods. The condition will work with all standard comparison operators (`==`, `>`, `>=`, `<`, `<=`, `!=`) through Apoli's `Comparison` enum.

### Example 1: Multiple aspects (OR check)
```json
{
  "type": "apoli:action_over_time",
  "entity_action": {
    "type": "apoli:execute_command",
    "command": "tellraw @a {\"text\": \"You Have the Ignis and Terra Aspects!\", \"color\": \"red\"}"
  },
  "interval": 40,
  "condition": {
    "type": "sync:has_aspect",
    "aspects": [
      "aspectslib:terra",
      "aspectslib:ignis"
    ],
    "min": 3
  }
}
```

### Example 2: Single aspect with custom comparison
```json
{
  "type": "apoli:action_over_time",
  "entity_action": {
    "type": "apoli:execute_command",
    "command": "tellraw @a {\"text\": \"You Have the Terra Aspect!\", \"color\": \"green\"}"
  },
  "interval": 40,
  "condition": {
    "type": "sync:has_aspect",
    "aspect": "aspectslib:terra",
    "min": 5,
    "comparison": ">="
  }
}
```

### Key points about the JSON format:
1. **`aspect`**: Single aspect ID (e.g., `"aspectslib:terra"`)
2. **`aspects`**: Array of aspect IDs for OR checking
3. **`min`**: Minimum required aspect level
4. **`comparison`**: (Optional) Comparison operator. Supports:
   - `"=="` (equal to)
   - `">"` (greater than)
   - `">="` (greater than or equal to)
   - `"<"` (less than)
   - `"<="` (less than or equal to)
   - `"!="` (not equal to)

If you omit the `comparison` field, it will default to `">="` (greater than or equal to), so these two conditions are equivalent:

```json
{
  "type": "sync:has_aspect",
  "aspect": "aspectslib:vitreus",
  "min": 10
}
```

```json
{
  "type": "sync:has_aspect",
  "aspect": "aspectslib:vitreus",
  "min": 10,
  "comparison": ">="
}
```