### PR TITLE
Added `Print` entity action

### DIFF
--- a/src/main/java/dev/overgrown/sync/factory/action/entity/PrintAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/PrintAction.java
@@ -1,0 +1,39 @@
+package dev.overgrown.sync.factory.action.entity;
+
+import dev.overgrown.sync.Sync;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PrintAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("Sync/PrintAction");
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(
+                Sync.identifier("print"),
+                new SerializableData()
+                        .add("message", SerializableDataTypes.STRING)
+                        .add("show_in_chat", SerializableDataTypes.BOOLEAN, false),
+                PrintAction::execute
+        );
+    }
+
+    private static void execute(SerializableData.Instance data, Entity entity) {
+        String message = data.getString("message");
+        boolean showInChat = data.getBoolean("show_in_chat");
+
+        // Log to console
+        LOGGER.info(message);
+
+        // Send to player chat if enabled and entity is a player
+        if (showInChat && entity instanceof ServerPlayerEntity player) {
+            player.sendMessage(Text.literal(message), false);
+        }
+    }
+}

--- a/src/main/java/dev/overgrown/sync/factory/registry/SyncTypeRegistry.java
+++ b/src/main/java/dev/overgrown/sync/factory/registry/SyncTypeRegistry.java
@@ -7,6 +7,7 @@ import dev.overgrown.sync.factory.action.bientity.AddToEntitySetAction;
 import dev.overgrown.sync.factory.action.bientity.RemoveFromEntitySetAction;
 import dev.overgrown.sync.factory.action.block.SpawnEntityBlockAction;
 import dev.overgrown.sync.factory.action.entity.ActionOnEntitySetAction;
+import dev.overgrown.sync.factory.action.entity.PrintAction;
 import dev.overgrown.sync.factory.action.entity.RandomTeleportAction;
 import dev.overgrown.sync.factory.condition.entity.*;
 import dev.overgrown.sync.factory.power.type.ActionOnDeathPower;
@@ -27,6 +28,7 @@ public class SyncTypeRegistry {
         // ========== ENTITY ACTION REGISTRATIONS ==========
         ApoliRegistryHelper.registerEntityAction(ActionOnEntitySetAction.getFactory());
         ApoliRegistryHelper.registerEntityAction(RandomTeleportAction.getFactory());
+        ApoliRegistryHelper.registerEntityAction(PrintAction.getFactory());
 
         // ========== BLOCK ACTION REGISTRATIONS ==========
         ApoliRegistryHelper.registerBlockAction(SpawnEntityBlockAction.getFactory());

--- a/src/main/resources/data/sync/powers/print_action_on_console_and_chat.json
+++ b/src/main/resources/data/sync/powers/print_action_on_console_and_chat.json
@@ -1,0 +1,9 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "sync:print",
+    "message": "Oh, look! I'm both in-game AND the console!!!",
+    "show_in_chat": true
+  },
+  "interval": 20
+}

--- a/src/main/resources/data/sync/powers/print_action_on_console_only.json
+++ b/src/main/resources/data/sync/powers/print_action_on_console_only.json
@@ -1,0 +1,9 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "sync:print",
+    "message": "Oh, look! I'm in the console!!!",
+    "show_in_chat": false
+  },
+  "interval": 20
+}


### PR DESCRIPTION
Implemented a `Print` entity action that logs the message to the console using SLF4J logger with a boolean that sends the message to the player's chat if `show_in_chat` is true (uses Minecraft's Text system for chat messages).

You can use this action in your JSON files like:
```json
{
    "type": "sync:print",
    "message": "Debug message here",
    "show_in_chat": true
}
```