### PR TITLE
Added Customizable Logger ID For Print Action

### DIFF
--- a/src/main/java/dev/overgrown/sync/factory/action/entity/PrintAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/PrintAction.java
@@ -12,14 +12,13 @@ import org.slf4j.LoggerFactory;
 
 public class PrintAction {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger("Sync/PrintAction");
-
     public static ActionFactory<Entity> getFactory() {
         return new ActionFactory<>(
                 Sync.identifier("print"),
                 new SerializableData()
                         .add("message", SerializableDataTypes.STRING)
-                        .add("show_in_chat", SerializableDataTypes.BOOLEAN, false),
+                        .add("show_in_chat", SerializableDataTypes.BOOLEAN, false)
+                        .add("logger_id", SerializableDataTypes.STRING, "Sync/PrintAction"),
                 PrintAction::execute
         );
     }
@@ -27,9 +26,13 @@ public class PrintAction {
     private static void execute(SerializableData.Instance data, Entity entity) {
         String message = data.getString("message");
         boolean showInChat = data.getBoolean("show_in_chat");
+        String loggerId = data.getString("logger_id"); // Get the custom logger ID
+
+        // Create logger with custom ID or default
+        Logger logger = LoggerFactory.getLogger(loggerId);
 
         // Log to console
-        LOGGER.info(message);
+        logger.info(message);
 
         // Send to player chat if enabled and entity is a player
         if (showInChat && entity instanceof ServerPlayerEntity player) {

--- a/src/main/resources/data/sync/powers/print_action.json
+++ b/src/main/resources/data/sync/powers/print_action.json
@@ -1,0 +1,61 @@
+{
+
+  "type": "apoli:multiple",
+  "resource": {
+    "type": "apoli:resource",
+    "min": 0,
+    "max": 2,
+    "hud_render": {
+      "should_render": false
+    }
+  },
+  "prints": {
+    "type": "apoli:action_over_time",
+    "entity_action": {
+      "type": "apoli:if_else_list",
+      "actions": [
+        {
+          "condition": {
+            "type": "apoli:resource",
+            "resource": "sync:print_action_resource",
+            "comparison": "==",
+            "compare_to": 0
+          },
+          "action": {
+            "type": "sync:print",
+            "message": "Oh, look! I'm in the console!!!",
+            "show_in_chat": false
+          }
+        },
+        {
+          "condition": {
+            "type": "apoli:resource",
+            "resource": "sync:print_action_resource",
+            "comparison": "==",
+            "compare_to": 1
+          },
+          "action": {
+            "type": "sync:print",
+            "message": "Oh, look! I'm both in-game AND the console!!!",
+            "show_in_chat": true
+          }
+        },
+        {
+          "condition": {
+            "type": "apoli:resource",
+            "resource": "sync:print_action_resource",
+            "comparison": "==",
+            "compare_to": 2
+          },
+          "action": {
+            "type": "sync:print",
+            "message": "Oh, look! A print message with a custom ID in the console",
+            "show_in_chat": true,
+            "logger_id": "MyCustomMod/MyPrintAction"
+          }
+        }
+      ]
+    },
+    "interval": 20
+  }
+}

--- a/src/main/resources/data/sync/powers/print_action_on_console_and_chat.json
+++ b/src/main/resources/data/sync/powers/print_action_on_console_and_chat.json
@@ -1,9 +1,0 @@
-{
-  "type": "apoli:action_over_time",
-  "entity_action": {
-    "type": "sync:print",
-    "message": "Oh, look! I'm both in-game AND the console!!!",
-    "show_in_chat": true
-  },
-  "interval": 20
-}

--- a/src/main/resources/data/sync/powers/print_action_on_console_only.json
+++ b/src/main/resources/data/sync/powers/print_action_on_console_only.json
@@ -1,9 +1,0 @@
-{
-  "type": "apoli:action_over_time",
-  "entity_action": {
-    "type": "sync:print",
-    "message": "Oh, look! I'm in the console!!!",
-    "show_in_chat": false
-  },
-  "interval": 20
-}


### PR DESCRIPTION
Added a new `logger_id` field to the SerializableData with a default value of `Sync/PrintAction` and modified the execute method to retrieve the logger ID from the data. I also created a logger instance using the custom ID instead of a static logger and removed the static logger since we now create loggers dynamically

This allows users to customize the logger ID in their JSON files like this:
```json
{
    "type": "sync:print",
    "message": "Hello World",
    "show_in_chat": true,
    "logger_id": "MyCustomMod/MyPrintAction"
}
```

If they don't specify a `logger_id`, it will default to "Sync/PrintAction" maintaining backward compatibility.