### PR TITLE
Modified Teleportation actions for Raycast compatibility and target tracking

### DIFF
--- a/src/main/java/dev/overgrown/sync/factory/action/bientity/save_location/SaveLocationBientityAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/bientity/save_location/SaveLocationBientityAction.java
@@ -1,0 +1,74 @@
+package dev.overgrown.sync.factory.action.bientity.save_location;
+
+import dev.overgrown.sync.Sync;
+import dev.overgrown.sync.factory.action.entity.teleportation.SaveLocationAction;
+import dev.overgrown.sync.factory.action.entity.teleportation.data.EntityLocationsState;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Pair;
+
+/**
+ * Bientity action that lets the actor save the target's location under a given id.
+ *
+ * <p>If {@code track_entity} is true, the saved location follows the target across
+ * future ticks (resolved at teleport time); otherwise the target's current position
+ * is frozen as a static location. Useful for composing with raycast bientity_action,
+ * collisions, or any other actor+target context.</p>
+ */
+public class SaveLocationBientityAction {
+
+    public static void action(SerializableData.Instance data, Pair<Entity, Entity> pair) {
+        Entity actor = pair.getLeft();
+        Entity target = pair.getRight();
+
+        if (!(actor.getWorld() instanceof ServerWorld serverWorld)) {
+            return;
+        }
+
+        String id = data.getString("id");
+        boolean overwrite = data.getBoolean("overwrite");
+        boolean trackEntity = data.getBoolean("track_entity");
+
+        boolean isPersistent = SaveLocationAction.isEntityPersistent(actor);
+        EntityLocationsState state = EntityLocationsState.get(serverWorld.getServer());
+
+        if (trackEntity) {
+            state.saveTrackedLocation(
+                    actor.getUuid(),
+                    id,
+                    target.getUuid(),
+                    target.getPos(),
+                    target.getWorld().getRegistryKey(),
+                    target.getYaw(),
+                    target.getPitch(),
+                    overwrite,
+                    isPersistent
+            );
+        } else {
+            state.saveStaticLocation(
+                    actor.getUuid(),
+                    id,
+                    target.getPos(),
+                    target.getWorld().getRegistryKey(),
+                    target.getYaw(),
+                    target.getPitch(),
+                    overwrite,
+                    isPersistent
+            );
+        }
+    }
+
+    public static ActionFactory<Pair<Entity, Entity>> getFactory() {
+        return new ActionFactory<>(
+                Sync.identifier("save_location"),
+                new SerializableData()
+                        .add("id", SerializableDataTypes.STRING)
+                        .add("overwrite", SerializableDataTypes.BOOLEAN, true)
+                        .add("track_entity", SerializableDataTypes.BOOLEAN, false),
+                SaveLocationBientityAction::action
+        );
+    }
+}

--- a/src/main/java/dev/overgrown/sync/factory/action/entity/raycast/RaycastAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/raycast/RaycastAction.java
@@ -1,6 +1,8 @@
 package dev.overgrown.sync.factory.action.entity.raycast;
 
 import dev.overgrown.sync.Sync;
+import dev.overgrown.sync.factory.action.entity.teleportation.SaveLocationAction;
+import dev.overgrown.sync.factory.action.entity.teleportation.data.EntityLocationsState;
 import dev.overgrown.sync.factory.data.raycast.RaycastUtil;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
@@ -139,6 +141,16 @@ public class RaycastAction {
             }
         }
 
+        // Save the hit position (or entity reference) into the actor's saved-location store.
+        // This is the only way to "save_location" from a block hit, since block_actions
+        // have no access to the actor entity that fired the raycast.
+        if (didHit && data.isPresent("save_location_id") && entity.getWorld() instanceof ServerWorld saveWorld) {
+            saveHitLocation(saveWorld, entity, primaryHit,
+                    data.getString("save_location_id"),
+                    data.getBoolean("save_location_overwrite"),
+                    data.getBoolean("save_location_track_entity"));
+        }
+
         // Hit Branch
         if (didHit) {
             // command_at_hit
@@ -189,6 +201,49 @@ public class RaycastAction {
             // Miss Branch
         } else {
             data.<Consumer<Entity>>ifPresent("miss_action", a -> a.accept(entity));
+        }
+    }
+
+    /**
+     * Persists either the hit block position or the hit entity's position/UUID into the
+     * actor's saved-location store. For block hits, the saved point sits flush against
+     * the hit face so the actor lands outside the block when teleporting back.
+     * Cross-dimensional and dimension-agnostic — the store is anchored on the overworld.
+     */
+    private static void saveHitLocation(ServerWorld serverWorld, Entity actor, HitResult primaryHit,
+                                        String id, boolean overwrite, boolean trackEntity) {
+        EntityLocationsState state = EntityLocationsState.get(serverWorld.getServer());
+        boolean isPersistent = SaveLocationAction.isEntityPersistent(actor);
+
+        if (primaryHit instanceof EntityHitResult ehr) {
+            Entity target = ehr.getEntity();
+            if (trackEntity) {
+                state.saveTrackedLocation(actor.getUuid(), id, target.getUuid(),
+                        target.getPos(), target.getWorld().getRegistryKey(),
+                        target.getYaw(), target.getPitch(),
+                        overwrite, isPersistent);
+            } else {
+                state.saveStaticLocation(actor.getUuid(), id,
+                        target.getPos(), target.getWorld().getRegistryKey(),
+                        target.getYaw(), target.getPitch(),
+                        overwrite, isPersistent);
+            }
+        } else if (primaryHit instanceof BlockHitResult bhr) {
+            BlockPos blockPos = bhr.getBlockPos();
+            Direction side = bhr.getSide();
+            Vec3d pos;
+            if (side == Direction.UP) {
+                pos = new Vec3d(blockPos.getX() + 0.5, blockPos.getY() + 1.0, blockPos.getZ() + 0.5);
+            } else if (side == Direction.DOWN) {
+                pos = new Vec3d(blockPos.getX() + 0.5, blockPos.getY() - actor.getHeight(), blockPos.getZ() + 0.5);
+            } else {
+                BlockPos adjacent = blockPos.offset(side);
+                pos = new Vec3d(adjacent.getX() + 0.5, blockPos.getY(), adjacent.getZ() + 0.5);
+            }
+            state.saveStaticLocation(actor.getUuid(), id,
+                    pos, serverWorld.getRegistryKey(),
+                    actor.getYaw(), actor.getPitch(),
+                    overwrite, isPersistent);
         }
     }
 
@@ -297,7 +352,13 @@ public class RaycastAction {
                         .add("command_hit_offset", SerializableDataTypes.FLOAT, null)
                         .add("command_along_ray", SerializableDataTypes.STRING, null)
                         .add("command_step", SerializableDataTypes.FLOAT, 1.0f)
-                        .add("command_along_ray_only_on_hit", SerializableDataTypes.BOOLEAN, false),
+                        .add("command_along_ray_only_on_hit", SerializableDataTypes.BOOLEAN, false)
+                        // save_location: store hit point/entity reference for the raycaster
+                        // (block hits have no actor context in apoli's block_action, so we
+                        // expose this directly on the raycast for the block-hit case)
+                        .add("save_location_id", SerializableDataTypes.STRING, null)
+                        .add("save_location_overwrite", SerializableDataTypes.BOOLEAN, true)
+                        .add("save_location_track_entity", SerializableDataTypes.BOOLEAN, false),
                 RaycastAction::action
         );
     }

--- a/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/SaveLocationAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/SaveLocationAction.java
@@ -23,8 +23,8 @@ public class SaveLocationAction {
         // Determine if this entity should be considered persistent
         boolean isPersistent = isEntityPersistent(entity);
 
-        EntityLocationsState state = EntityLocationsState.get(serverWorld);
-        state.saveLocation(
+        EntityLocationsState state = EntityLocationsState.get(serverWorld.getServer());
+        state.saveStaticLocation(
                 entity.getUuid(),
                 id,
                 entity.getPos(),
@@ -36,7 +36,7 @@ public class SaveLocationAction {
         );
     }
 
-    private static boolean isEntityPersistent(Entity entity) {
+    public static boolean isEntityPersistent(Entity entity) {
         // Players are always persistent
         if (entity instanceof ServerPlayerEntity) {
             return true;

--- a/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/TeleportToLocationAction.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/TeleportToLocationAction.java
@@ -18,60 +18,49 @@ public class TeleportToLocationAction {
         }
 
         String id = data.getString("id");
+        MinecraftServer server = serverWorld.getServer();
 
-        EntityLocationsState state = EntityLocationsState.get(serverWorld);
-        EntityLocationsState.SavedLocation savedLocation = state.getLocation(entity.getUuid(), id);
+        EntityLocationsState state = EntityLocationsState.get(server);
+        EntityLocationsState.ResolvedLocation resolved = state.resolve(server, entity.getUuid(), id);
 
-        if (savedLocation == null) {
+        if (resolved == null) {
             return;
         }
 
-        MinecraftServer server = serverWorld.getServer();
-        ServerWorld targetWorld = server.getWorld(savedLocation.dimension());
-
+        ServerWorld targetWorld = server.getWorld(resolved.dimension());
         if (targetWorld == null) {
             return;
         }
 
-        // Handle teleportation differently for players vs other entities
         if (entity instanceof ServerPlayerEntity player) {
-            // Player teleportation with rotation
             player.teleport(
                     targetWorld,
-                    savedLocation.position().x,
-                    savedLocation.position().y,
-                    savedLocation.position().z,
-                    savedLocation.yaw(),
-                    savedLocation.pitch()
+                    resolved.position().x,
+                    resolved.position().y,
+                    resolved.position().z,
+                    resolved.yaw(),
+                    resolved.pitch()
             );
         } else {
-            // Non-player entity teleportation
             Entity teleportedEntity = entity;
 
-            // If changing dimensions, use moveToWorld
-            if (!entity.getWorld().getRegistryKey().equals(savedLocation.dimension())) {
+            if (!entity.getWorld().getRegistryKey().equals(resolved.dimension())) {
                 teleportedEntity = entity.moveToWorld(targetWorld);
                 if (teleportedEntity == null) {
-                    return; // Failed to move between dimensions
+                    return;
                 }
             }
 
-            // Set position and rotation
             teleportedEntity.refreshPositionAndAngles(
-                    savedLocation.position().x,
-                    savedLocation.position().y,
-                    savedLocation.position().z,
-                    savedLocation.yaw(),
-                    savedLocation.pitch()
+                    resolved.position().x,
+                    resolved.position().y,
+                    resolved.position().z,
+                    resolved.yaw(),
+                    resolved.pitch()
             );
-
-            // For non-player entities, also set head yaw
-            teleportedEntity.setHeadYaw(savedLocation.yaw());
-
-            // Stop riding if entity is riding something
+            teleportedEntity.setHeadYaw(resolved.yaw());
             teleportedEntity.stopRiding();
 
-            // For mobs, stop their navigation
             if (teleportedEntity instanceof net.minecraft.entity.mob.PathAwareEntity pathAwareEntity) {
                 pathAwareEntity.getNavigation().stop();
             }

--- a/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/data/EntityLocationsState.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/data/EntityLocationsState.java
@@ -18,16 +18,25 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Server-global persistent storage for entity-saved teleport locations.
+ *
+ * <p>Anchored on the overworld's {@code PersistentStateManager} (same convention vanilla
+ * uses for {@code MapState}) so that locations saved in one dimension are visible from
+ * any other dimension. This is critical because {@code save_location} and
+ * {@code teleport_to_location} can run in different worlds.</p>
+ *
+ * <p>Locations may be either {@link Static} (frozen position) or {@link Tracked}
+ * (follows an entity by UUID; resolves to that entity's current position at teleport
+ * time). Tracked locations carry a position snapshot used as a fallback if the entity
+ * has been unloaded or removed.</p>
+ */
 public class EntityLocationsState extends PersistentState {
     private static final String STATE_NAME = "sync_entity_locations";
 
-    // Use ConcurrentHashMap for thread safety
     private final Map<UUID, EntityLocationData> entityLocations = new ConcurrentHashMap<>();
-
-    // Track when locations were last accessed for cleanup
     private final Map<UUID, Long> lastAccessTime = new ConcurrentHashMap<>();
 
-    // Configurable cleanup settings (in ticks, 20 ticks = 1 second)
     private static final long CLEANUP_INTERVAL = 20 * 60 * 10; // 10 minutes
     private static final long MAX_INACTIVE_TIME = 20 * 60 * 30; // 30 minutes for non-persistent entities
     private long lastCleanupTime = 0;
@@ -36,24 +45,51 @@ public class EntityLocationsState extends PersistentState {
         super();
     }
 
+    /**
+     * Returns the server-global state, anchored to the overworld.
+     * Preferred over {@link #get(ServerWorld)} for cross-dimension consistency.
+     */
+    public static EntityLocationsState get(MinecraftServer server) {
+        return get(server.getOverworld());
+    }
+
+    /**
+     * Returns the server-global state. Despite the {@code ServerWorld} parameter,
+     * the state is always loaded from the overworld so saves are visible across dimensions.
+     */
     public static EntityLocationsState get(ServerWorld world) {
-        return world.getPersistentStateManager().getOrCreate(
+        ServerWorld anchor = world.getServer().getOverworld();
+        return anchor.getPersistentStateManager().getOrCreate(
                 EntityLocationsState::fromNbt,
                 EntityLocationsState::new,
                 STATE_NAME
         );
     }
 
-    public void saveLocation(UUID entityId, String id, Vec3d position, RegistryKey<World> dimension,
-                             float yaw, float pitch, boolean overwrite, boolean isPersistent) {
+    public void saveStaticLocation(UUID entityId, String id, Vec3d position, RegistryKey<World> dimension,
+                                   float yaw, float pitch, boolean overwrite, boolean isPersistent) {
+        putLocation(entityId, id, new Static(position, dimension, yaw, pitch), overwrite, isPersistent);
+    }
+
+    public void saveTrackedLocation(UUID entityId, String id, UUID targetUuid, Vec3d snapshotPos,
+                                    RegistryKey<World> snapshotDim, float snapshotYaw, float snapshotPitch,
+                                    boolean overwrite, boolean isPersistent) {
+        putLocation(entityId, id, new Tracked(targetUuid, snapshotPos, snapshotDim, snapshotYaw, snapshotPitch),
+                overwrite, isPersistent);
+    }
+
+    private void putLocation(UUID entityId, String id, SavedLocation location, boolean overwrite, boolean isPersistent) {
         EntityLocationData entityData = entityLocations.computeIfAbsent(entityId,
                 k -> new EntityLocationData(isPersistent));
 
         if (!overwrite && entityData.locations.containsKey(id)) {
-            return; // Don't overwrite if overwrite is false
+            return;
         }
 
-        entityData.locations.put(id, new SavedLocation(position, dimension, yaw, pitch));
+        entityData.locations.put(id, location);
+        if (isPersistent) {
+            entityData.isPersistent = true;
+        }
         lastAccessTime.put(entityId, System.currentTimeMillis());
         markDirty();
     }
@@ -64,10 +100,44 @@ public class EntityLocationsState extends PersistentState {
         if (entityData == null) {
             return null;
         }
-
-        // Update last access time
         lastAccessTime.put(entityId, System.currentTimeMillis());
         return entityData.locations.get(id);
+    }
+
+    /**
+     * Resolves a saved location into a concrete world position. For {@link Tracked}
+     * locations, this scans the server's worlds for the target entity and returns its
+     * live position; if the entity is gone, falls back to the last-known snapshot.
+     */
+    @Nullable
+    public ResolvedLocation resolve(MinecraftServer server, UUID entityId, String id) {
+        SavedLocation saved = getLocation(entityId, id);
+        if (saved == null) {
+            return null;
+        }
+        return resolveSaved(server, saved);
+    }
+
+    public static ResolvedLocation resolveSaved(MinecraftServer server, SavedLocation saved) {
+        if (saved instanceof Static s) {
+            return new ResolvedLocation(s.position(), s.dimension(), s.yaw(), s.pitch());
+        }
+        if (saved instanceof Tracked t) {
+            for (ServerWorld world : server.getWorlds()) {
+                Entity entity = world.getEntity(t.targetUuid());
+                if (entity != null && entity.isAlive()) {
+                    return new ResolvedLocation(
+                            entity.getPos(),
+                            entity.getWorld().getRegistryKey(),
+                            entity.getYaw(),
+                            entity.getPitch()
+                    );
+                }
+            }
+            // Fallback to snapshot when the tracked entity is unavailable.
+            return new ResolvedLocation(t.snapshotPosition(), t.snapshotDimension(), t.snapshotYaw(), t.snapshotPitch());
+        }
+        return null;
     }
 
     public boolean removeLocation(UUID entityId, String id) {
@@ -75,7 +145,6 @@ public class EntityLocationsState extends PersistentState {
         if (entityData == null) {
             return false;
         }
-
         boolean removed = entityData.locations.remove(id) != null;
         if (removed) {
             markDirty();
@@ -90,14 +159,9 @@ public class EntityLocationsState extends PersistentState {
         }
     }
 
-    /**
-     * Periodic cleanup to remove locations for entities that no longer exist
-     */
     public void cleanupLocations(MinecraftServer server) {
         long currentTime = System.currentTimeMillis();
-
-        // Only run cleanup every CLEANUP_INTERVAL
-        if (currentTime - lastCleanupTime < CLEANUP_INTERVAL * 50) { // Convert ticks to ms
+        if (currentTime - lastCleanupTime < CLEANUP_INTERVAL * 50) {
             return;
         }
 
@@ -110,23 +174,17 @@ public class EntityLocationsState extends PersistentState {
             UUID entityId = entry.getKey();
             EntityLocationData data = entry.getValue();
 
-            // Always keep player data (players are persistent)
             if (isPlayer(entityId, server)) {
                 continue;
             }
 
-            // For non-persistent entities, check if they're still alive
             if (!data.isPersistent) {
                 boolean entityExists = false;
 
-                // Check all worlds for this entity
                 for (ServerWorld world : server.getWorlds()) {
                     Entity entity = world.getEntity(entityId);
                     if (entity != null && entity.isAlive()) {
                         entityExists = true;
-
-                        // Check if this entity should be considered persistent now
-                        // (e.g., if it was name-tagged after saving location)
                         if (entity.hasCustomName() || entity instanceof PathAwareEntity) {
                             data.isPersistent = true;
                         }
@@ -134,11 +192,10 @@ public class EntityLocationsState extends PersistentState {
                     }
                 }
 
-                // If entity doesn't exist and hasn't been accessed recently, remove it
                 if (!entityExists) {
                     Long lastAccess = lastAccessTime.get(entityId);
-                    if (lastAccess == null ||
-                            currentTime - lastAccess > MAX_INACTIVE_TIME * 50) {
+                    if (lastAccess == null
+                            || currentTime - lastAccess > MAX_INACTIVE_TIME * 50) {
                         iterator.remove();
                         lastAccessTime.remove(entityId);
                         changed = true;
@@ -153,7 +210,6 @@ public class EntityLocationsState extends PersistentState {
     }
 
     private boolean isPlayer(UUID uuid, MinecraftServer server) {
-        // Check if this UUID belongs to a player
         return server.getPlayerManager().getPlayer(uuid) != null;
     }
 
@@ -179,12 +235,20 @@ public class EntityLocationsState extends PersistentState {
                 );
                 RegistryKey<World> dimension = World.OVERWORLD;
                 if (locationCompound.contains("dimension")) {
-                    dimension = RegistryKey.of(RegistryKeys.WORLD, new Identifier(locationCompound.getString("dimension")));
+                    dimension = RegistryKey.of(RegistryKeys.WORLD,
+                            new Identifier(locationCompound.getString("dimension")));
                 }
                 float yaw = locationCompound.getFloat("yaw");
                 float pitch = locationCompound.getFloat("pitch");
 
-                locations.put(id, new SavedLocation(position, dimension, yaw, pitch));
+                SavedLocation saved;
+                if (locationCompound.containsUuid("target_uuid")) {
+                    UUID target = locationCompound.getUuid("target_uuid");
+                    saved = new Tracked(target, position, dimension, yaw, pitch);
+                } else {
+                    saved = new Static(position, dimension, yaw, pitch);
+                }
+                locations.put(id, saved);
             }
 
             state.entityLocations.put(entityId, new EntityLocationData(locations, isPersistent));
@@ -206,12 +270,20 @@ public class EntityLocationsState extends PersistentState {
             for (Map.Entry<String, SavedLocation> locationEntry : entityEntry.getValue().locations.entrySet()) {
                 NbtCompound locationCompound = new NbtCompound();
                 locationCompound.putString("id", locationEntry.getKey());
-                locationCompound.putDouble("x", locationEntry.getValue().position().x);
-                locationCompound.putDouble("y", locationEntry.getValue().position().y);
-                locationCompound.putDouble("z", locationEntry.getValue().position().z);
-                locationCompound.putString("dimension", locationEntry.getValue().dimension().getValue().toString());
-                locationCompound.putFloat("yaw", locationEntry.getValue().yaw());
-                locationCompound.putFloat("pitch", locationEntry.getValue().pitch());
+
+                SavedLocation loc = locationEntry.getValue();
+                Vec3d pos = loc.position();
+                RegistryKey<World> dim = loc.dimension();
+                locationCompound.putDouble("x", pos.x);
+                locationCompound.putDouble("y", pos.y);
+                locationCompound.putDouble("z", pos.z);
+                locationCompound.putString("dimension", dim.getValue().toString());
+                locationCompound.putFloat("yaw", loc.yaw());
+                locationCompound.putFloat("pitch", loc.pitch());
+
+                if (loc instanceof Tracked t) {
+                    locationCompound.putUuid("target_uuid", t.targetUuid());
+                }
 
                 locationsList.add(locationCompound);
             }
@@ -224,21 +296,54 @@ public class EntityLocationsState extends PersistentState {
         return nbt;
     }
 
-    // Inner class to store location data with persistence flag
     private static class EntityLocationData {
         private final Map<String, SavedLocation> locations;
         private boolean isPersistent;
 
-        public EntityLocationData(boolean isPersistent) {
+        EntityLocationData(boolean isPersistent) {
             this.locations = new HashMap<>();
             this.isPersistent = isPersistent;
         }
 
-        public EntityLocationData(Map<String, SavedLocation> locations, boolean isPersistent) {
+        EntityLocationData(Map<String, SavedLocation> locations, boolean isPersistent) {
             this.locations = locations;
             this.isPersistent = isPersistent;
         }
     }
 
-    public record SavedLocation(Vec3d position, RegistryKey<World> dimension, float yaw, float pitch) {}
+    public sealed interface SavedLocation permits Static, Tracked {
+        Vec3d position();
+        RegistryKey<World> dimension();
+        float yaw();
+        float pitch();
+    }
+
+    public record Static(Vec3d position, RegistryKey<World> dimension, float yaw, float pitch)
+            implements SavedLocation {}
+
+    public record Tracked(UUID targetUuid,
+                          Vec3d snapshotPosition, RegistryKey<World> snapshotDimension,
+                          float snapshotYaw, float snapshotPitch) implements SavedLocation {
+        @Override
+        public Vec3d position() {
+            return snapshotPosition;
+        }
+
+        @Override
+        public RegistryKey<World> dimension() {
+            return snapshotDimension;
+        }
+
+        @Override
+        public float yaw() {
+            return snapshotYaw;
+        }
+
+        @Override
+        public float pitch() {
+            return snapshotPitch;
+        }
+    }
+
+    public record ResolvedLocation(Vec3d position, RegistryKey<World> dimension, float yaw, float pitch) {}
 }

--- a/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/events/EntityCleanupHandler.java
+++ b/src/main/java/dev/overgrown/sync/factory/action/entity/teleportation/events/EntityCleanupHandler.java
@@ -13,55 +13,44 @@ import net.minecraft.server.world.ServerWorld;
 public class EntityCleanupHandler {
 
     public static void register() {
-        // Clean up locations when entities die
         ServerLivingEntityEvents.AFTER_DEATH.register((entity, damageSource) -> {
-            // Direct cast to ServerWorld since we know it's server-side
             ServerWorld serverWorld = (ServerWorld) entity.getWorld();
 
-            // Don't clean up player data on death (players respawn)
             if (entity instanceof ServerPlayerEntity) {
                 return;
             }
 
-            // Only cleanup entities whose data should be removed
             if (shouldRemoveEntityData(entity)) {
-                EntityLocationsState state = EntityLocationsState.get(serverWorld);
+                EntityLocationsState state = EntityLocationsState.get(serverWorld.getServer());
                 state.removeAllLocationsForEntity(entity.getUuid());
             }
         });
 
-        // Clean up locations when entities are unloaded/removed
         ServerEntityEvents.ENTITY_UNLOAD.register((entity, world) -> {
             ServerWorld serverWorld = (ServerWorld) world;
 
-            // Don't clean up player data
             if (entity instanceof ServerPlayerEntity) {
                 return;
             }
 
-            // Only cleanup if entity is dead or shouldn't be persistent
             if (entity instanceof LivingEntity livingEntity && !livingEntity.isAlive()) {
                 if (shouldRemoveEntityData(entity)) {
-                    EntityLocationsState state = EntityLocationsState.get(serverWorld);
+                    EntityLocationsState state = EntityLocationsState.get(serverWorld.getServer());
                     state.removeAllLocationsForEntity(entity.getUuid());
                 }
             }
         });
 
-        // Periodic cleanup for entities that might have been removed without events
+        // State is server-global (anchored on overworld), so we cleanup once per tick.
         ServerTickEvents.END_SERVER_TICK.register(server -> {
-            // Run cleanup on all worlds
-            for (ServerWorld world : server.getWorlds()) {
-                EntityLocationsState state = EntityLocationsState.get(world);
-                state.cleanupLocations(server);
-            }
+            EntityLocationsState state = EntityLocationsState.get(server);
+            state.cleanupLocations(server);
         });
     }
 
     private static boolean shouldRemoveEntityData(Entity entity) {
-        // Remove data for entities that are not players, not name-tagged, and not PathAwareEntity
-        return !(entity instanceof ServerPlayerEntity ||
-                entity.hasCustomName() ||
-                entity instanceof PathAwareEntity);
+        return !(entity instanceof ServerPlayerEntity
+                || entity.hasCustomName()
+                || entity instanceof PathAwareEntity);
     }
 }

--- a/src/main/java/dev/overgrown/sync/registry/factory/SyncTypeRegistry.java
+++ b/src/main/java/dev/overgrown/sync/registry/factory/SyncTypeRegistry.java
@@ -28,6 +28,7 @@ import dev.overgrown.sync.factory.compatibility.aspectslib.power.type.SetEntityA
 import dev.overgrown.sync.factory.compatibility.aspectslib.condition.entity.HasAspectCondition;
 import dev.overgrown.sync.factory.action.bientity.add_to_entity_set.AddToEntitySetAction;
 import dev.overgrown.sync.factory.action.bientity.remove_from_entity_set.RemoveFromEntitySetAction;
+import dev.overgrown.sync.factory.action.bientity.save_location.SaveLocationBientityAction;
 import dev.overgrown.sync.factory.action.block.ghost_block.GhostBlockAction;
 import dev.overgrown.sync.factory.action.block.spawn_entity_block.SpawnEntityBlockAction;
 import dev.overgrown.sync.factory.action.entity.action_on_entity_set.ActionOnEntitySetAction;
@@ -178,6 +179,7 @@ public class SyncTypeRegistry {
         ApoliRegistryHelper.registerBientityAction(LiberatePowerAction.getFactory());
         ApoliRegistryHelper.registerBientityAction(RemoveFromEntitySetAction.getFactory());
         ApoliRegistryHelper.registerBientityAction(RopeLeashAction.getFactory());
+        ApoliRegistryHelper.registerBientityAction(SaveLocationBientityAction.getFactory());
         ApoliRegistryHelper.registerBientityAction(SuppressPowerAction.getFactory());
         ApoliRegistryHelper.registerBientityAction(TransferAction.getFactory());
 


### PR DESCRIPTION
 ### Summary of changes:
- `EntityLocationsState.java` is refactored, now it's anchored on the overworld's `PersistentStateManager`, so saves persist across dimensions (vanilla uses the same trick for `MapState`). Previously a save in the Nether was invisible from the Overworld.
- `SavedLocation` is now a sealed type with two variants: Static (frozen pos/dim) and Tracked (follows an entity by UUID; falls back to a snapshot if the entity is gone).
- NBT format is backward-compatible, old saves load as Static. The only new field is `target_uuid` for tracked entries.
- Storage uses `RegistryKey<World>` (registry-based identifiers), so any vanilla or modded dimension works.

`SaveLocationAction`, `TeleportToLocationAction`, `EntityCleanupHandler` have been updated to use the server-level state. `TeleportToLocationAction` resolves tracked locations to the entity's current position at teleport time; cleanup runs once per server tick instead of once per world.

`RaycastAction` has three new fields:
- `save_location_id` (string, optional): when a hit lands and this is set, save the hit point for the raycaster.
- `save_location_overwrite` (defaults to `true`).
- `save_location_track_entity` (default to `false`): if the hit is an entity, save by UUID so future `teleport_to_location` calls follow that entity.

For block hits, the saved point sits flush against the hit face (top of the block for an UP face, adjacent block for sides, etc.) so the teleport doesn't drop you inside geometry.

Added a new bientity action: `sync:save_location`. Actor saves target's location under id. Composable in any actor + target context. Same overwrite/track_entity flags.

### Why this design?
- No new `block_action`. Apoli's `block_action` signature is `Triple<World`, `BlockPos`, `Direction>`. No actor. So, a "Save Location (Block Action Type)" can't know whose location to save. Wiring directly into the raycast keeps actor context and avoids a context-less, footgun action.
- Performance. Reuses the existing `EntityLocationsState` (concurrent maps, persistent-state dirty flag, scheduled cleanup). One UUID -> entity scan only happens on a `teleport_to_location` call against a tracked entry that's bounded by `server.getWorlds().size()` and only on demand.
- No client networking added. All state is server-side.
- Modded dimensions are now stored as `RegistryKey<World>`, identical to how vanilla stores the player's spawn dimension.

### Example data JSON

```json
   "entity_action":{
      "type":"sync:raycast",
      "save_location_id":"marker",
      "save_location_track_entity":true
   }
```

Then later:
```json
   "entity_action":{
      "type":"sync:teleport_to_location",
      "id":"marker"
   }
```

Or via the bientity action:
```json
{
   "entity_action":{
      "type":"sync:save_location",
      "id":"last_target",
      "track_entity":true
   }
}
```